### PR TITLE
Fixing main path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Mike Pugh <mikepugh82@gmail.com>"
   ],
   "description": "Angular JS based service wrapper for various geolocation services",
-  "main": "angulargeo.js",
+  "main": "dist/angulargeo.js",
   "keywords": [
     "angular",
     "geolocation"


### PR DESCRIPTION
Bower.json's main path was bad, causing [https://github.com/taptapship/wiredep](wiredep) failing to load the plugin from bower.json information.